### PR TITLE
ci(semantic-release): use config property

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -7,13 +7,13 @@ module.exports = {
     [
       '@semantic-release/release-notes-generator',
       {
-        preset: '@attest/conventional-changelog',
+        config: '@attest/conventional-changelog',
       },
     ],
     [
       '@semantic-release/changelog',
       {
-        preset: '@attest/conventional-changelog',
+        config: '@attest/conventional-changelog',
         changelogFile: 'CHANGELOG.md',
       },
     ],


### PR DESCRIPTION
use config property over preset; preset will not resolve the module but attempt to use one of the standard presets available

[ch8743]