### PR TITLE
fix(semantic-release): update included assets

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -17,11 +17,18 @@ module.exports = {
         changelogFile: 'CHANGELOG.md',
       },
     ],
-    '@semantic-release/github',
     [
-      '@semantic-release/git',
+      '@semantic-release/github',
       {
-        assets: ['CHANGELOG.md', 'dist/**'],
+        assets: [
+          'CHANGELOG.md',
+          'dist/**',
+          'node_modules/**',
+          'package.json',
+          'yarn.lock',
+          'action.yml',
+          'LICENSE.md',
+        ],
       },
     ],
   ],


### PR DESCRIPTION
- only release to github releases; exclude doing a commit based release.
- include node_modules in release archive (required for github actions)

[ch8743]