### PR TITLE
docs(repo): add docs for expected structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ jobs:
           input: './annotations.json'
           title: 'Annotate Files'
 ```
+
+### Input file structure
+
+The expected structure for the input is defined [here in the source](https://github.com/Attest/annotations-action/blob/master/src/annotation.ts), for an example please look at [`annotations.json`](https://github.com/Attest/annotations-action/blob/master/annotations.json).

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "---------------CODEOWNERS--------------": ".",
     "codeowners": "yarn generate-codeowners",
     "--------------TYPECHECKING-------------": ".",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit --skipLibCheck",
     "----------------BUILD TOOLS----------------": ".",
     "build": "rollup -c",
     "----------------LINTING----------------": ".",


### PR DESCRIPTION
add documenation around the expected structure for the file input
structure with link to example

closes GH-8