### PR TITLE
ci(repo): automerge patch based updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,6 +4,10 @@ update_configs:
     directory: '/'
     update_schedule: 'weekly'
     version_requirement_updates: increase_versions
+    automerged_updates:
+      - match:
+          dependency_type: 'all'
+          update_type: 'semver:patch'
     default_labels:
       - '🤖 Dependency update'
     commit_message:

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -45,3 +45,7 @@ jobs:
           path: ./annotations.json
           title: Annotation Test
           token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: hmarr/auto-approve-action@v2.0.0
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Configure dependabot to auto merge patch based dependencies

Auto merge patch based dependendabot updates, add auto approve step to pull request check workflow to auto approve dependabot based PR's.

This requires; adding `dependabot-preview` bot to allow pushing to matching protected branches.

![image](https://user-images.githubusercontent.com/1624261/77428519-1d466800-6dd0-11ea-8dad-1ffe507f8f50.png)


gh-34